### PR TITLE
Updates exception assertion

### DIFF
--- a/tests/Cache.Tests/CacheServiceTests.cs
+++ b/tests/Cache.Tests/CacheServiceTests.cs
@@ -550,7 +550,7 @@ namespace PT.UnitTest
          var ex = await Assert.ThrowsAsync<ArgumentException>(() =>
             this.service.ExistsAsync(key, this.defaultOptions, this.cancellationToken));
 
-         Assert.Equal("Key cannot be null or empty (Parameter 'key')", ex.Message);
+         Assert.StartsWith("Key cannot be null or empty", ex.Message);
       }
 
       [Fact]


### PR DESCRIPTION
Updates the exception assertion to use StartsWith instead of Equal.

This allows for more flexibility in the exception message and avoids brittle tests.